### PR TITLE
AJ-1396 reinstate time

### DIFF
--- a/e2e-test/e2etest.py
+++ b/e2e-test/e2etest.py
@@ -1,6 +1,7 @@
 from helper import *
 from app_helper import poll_for_app_url
 import os
+import time
 
 # Setup configuration
 # These values should be injected into the environment before setup


### PR DESCRIPTION
`e2etest.py` has the line `from helper import *`.  `helper.py` used to import time but that line was removed in https://github.com/broadinstitute/dsp-reusable-workflows/pull/8, so this PR puts it back into `e2etest.py` where it is still needed.