### PR TITLE
AJ-1397 - Add workspace deletion to wds e2e test

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -62,4 +62,4 @@ jobs:
         run: |
           cd ${{ env.CHECKOUT_PATH }}${{ env.SCRIPT_PATH }}
           AZURE_TOKEN=${{ steps.obtain-token.outputs.access_token }}\
-            python e2etest.py
+            python wds_azure_e2etest.py


### PR DESCRIPTION
I renamed the test script as part of the previous AJ-1397 PR, but did not include the name change in the github actions file. This is causing the wds clone e2e test to fail.