### PR TITLE
AJ-1436 Don't poll if app doesn't exist

### DIFF
--- a/e2e-test/app_helper.py
+++ b/e2e-test/app_helper.py
@@ -35,7 +35,8 @@ def poll_for_app_url(workspaceId, app_type, proxy_url_name, azure_token, leo_url
     }
 
     # prevent infinite loop
-    polling_attempts_remaining = 30 # 30s x 30 = 15 min
+    max_polling_attempts = 30 # 30s x 30 = 15 min
+    polling_attempts_remaining = max_polling_attempts
     
     for i in range(0,shared_variables.RETRIES):
         try:
@@ -50,7 +51,7 @@ def poll_for_app_url(workspaceId, app_type, proxy_url_name, azure_token, leo_url
                     logging.warning(f"{app_type} not found in apps, has it been started?")
                     # The app *might* not appear in the list immediately; 
                     # let a few polls pass for it to get to PROVISIONING stage before quitting
-                    if polling_attempts_remaining < 10:
+                    if polling_attempts_remaining < max_polling_attempts - 2:
                         return ""
                     else:
                         time.sleep(30)

--- a/e2e-test/app_helper.py
+++ b/e2e-test/app_helper.py
@@ -35,8 +35,7 @@ def poll_for_app_url(workspaceId, app_type, proxy_url_name, azure_token, leo_url
     }
 
     # prevent infinite loop
-    max_polling_attempts = 30 # 30s x 30 = 15 min
-    polling_attempts_remaining = max_polling_attempts
+    polling_attempts_remaining = 30 # 30s x 30 = 15 min
     
     for i in range(0,shared_variables.RETRIES):
         try:
@@ -49,27 +48,21 @@ def poll_for_app_url(workspaceId, app_type, proxy_url_name, azure_token, leo_url
                 # Don't run in an infinite loop if you forgot to start the app/it was never created
                 if app_type not in [item['appType'] for item in response]:
                     logging.warning(f"{app_type} not found in apps, has it been started?")
-                    # The app *might* not appear in the list immediately; 
-                    # let a few polls pass for it to get to PROVISIONING stage before quitting
-                    if polling_attempts_remaining < max_polling_attempts - 2:
                         return ""
-                    else:
-                        time.sleep(30)
-                else:
-                    for entries in response:
-                        if entries['appType'] == app_type:
-                            if entries['status'] == "PROVISIONING":
-                                logging.info(f"{app_type} is still provisioning. Sleeping for 30 seconds")
-                                time.sleep(30)
-                            elif entries['status'] == 'ERROR':
-                                logging.error(f"{app_type} is in ERROR state. Error details: {entries['errors']}")
-                                return ""
-                            elif entries['proxyUrls'][proxy_url_name] is None:
-                                logging.error(f"{app_type} proxyUrls not found: {entries}")
-                                return ""
-                            else:
-                                logging.info(f"{app_type} is in READY state")
-                                return entries['proxyUrls'][proxy_url_name]
+                for entries in response:
+                    if entries['appType'] == app_type:
+                        if entries['status'] == "PROVISIONING":
+                            logging.info(f"{app_type} is still provisioning. Sleeping for 30 seconds")
+                            time.sleep(30)
+                        elif entries['status'] == 'ERROR':
+                            logging.error(f"{app_type} is in ERROR state. Error details: {entries['errors']}")
+                            return ""
+                        elif entries['proxyUrls'][proxy_url_name] is None:
+                            logging.error(f"{app_type} proxyUrls not found: {entries}")
+                            return ""
+                        else:
+                            logging.info(f"{app_type} is in READY state")
+                            return entries['proxyUrls'][proxy_url_name]
                 polling_attempts_remaining -= 1
         except Exception as e:
             logging.info(f"ERROR polling for app '{app_type}' in workspace '{workspaceId}'. Error: {e}")


### PR DESCRIPTION
https://github.com/broadinstitute/dsp-reusable-workflows/pull/20 added extra polling in the case of an app not appearing in the app list at all.  However, this method is used in some cases to check for the existence of an app at all (as opposed to expecting the app to exist and simply waiting for it to be ready), and in reality an app should be in the list returned from Leo by the time this method is called.  This PR removes that extra polling.