### PR TITLE
WX-1419 Increase wait time for workflow to complete

### DIFF
--- a/e2e-test/cromwell_azure_e2e_test.py
+++ b/e2e-test/cromwell_azure_e2e_test.py
@@ -66,13 +66,15 @@ def get_workflow_metadata(app_url, workflow_id, bearer_token):
     return perform_get(workflow_endpoint, bearer_token)
 
 # workflow_ids is a deque of workflow ids
-def get_completed_workflow(app_url, workflow_ids, bearer_token, max_retries=4, sleep_timer=60 * 2):
+def get_completed_workflow(app_url, workflow_ids, bearer_token, max_retries=6, sleep_timer=60 * 2):
     success_statuses = ['Succeeded']
     throw_exception_statuses = ['Aborted', 'Failed']
+
+    current_retries = max_retries
     
     current_running_workflow_count = 0
     while workflow_ids:
-        if max_retries == 0:
+        if current_retries == 0:
             raise Exception(f"Workflow(s) did not finish running within retry window ({max_retries} retries)")
         
         workflow_id = workflow_ids.pop()
@@ -94,10 +96,10 @@ def get_completed_workflow(app_url, workflow_ids, bearer_token, max_retries=4, s
                 logging.info("Workflow(s) finished running")
             else:
                 # Reset current count to 0 for next retry
-                # Decrement max_retries by 1
+                # Decrement current_retries by 1
                 # Wait for sleep_timer before checking workflow statuses again (adjust value as needed)
                 logging.info(f"These workflows have yet to return a completed status: [{', '.join(workflow_ids)}]")
-                max_retries -= 1
+                current_retries -= 1
                 current_running_workflow_count = 0
                 time.sleep(sleep_timer)
     logging.info("Workflow(s) submission and completion successful")

--- a/e2e-test/cromwell_azure_e2e_test.py
+++ b/e2e-test/cromwell_azure_e2e_test.py
@@ -66,16 +66,16 @@ def get_workflow_metadata(app_url, workflow_id, bearer_token):
     return perform_get(workflow_endpoint, bearer_token)
 
 # workflow_ids is a deque of workflow ids
-def get_completed_workflow(app_url, workflow_ids, bearer_token, max_retries=6, sleep_timer=60 * 2):
+def get_completed_workflow(app_url, workflow_ids, bearer_token, max_attempts=6, sleep_timer=60 * 2):
     success_statuses = ['Succeeded']
     throw_exception_statuses = ['Aborted', 'Failed']
 
-    current_retries = max_retries
+    remaining_attempts = max_attempts
     
     current_running_workflow_count = 0
     while workflow_ids:
-        if current_retries == 0:
-            raise Exception(f"Workflow(s) did not finish running within retry window ({max_retries} retries)")
+        if remaining_attempts == 0:
+            raise Exception(f"Workflow(s) did not finish running within retry window ({max_attempts} attempts)")
         
         workflow_id = workflow_ids.pop()
         workflow_status_json = get_workflow_status(app_url, workflow_id, bearer_token)
@@ -96,10 +96,10 @@ def get_completed_workflow(app_url, workflow_ids, bearer_token, max_retries=6, s
                 logging.info("Workflow(s) finished running")
             else:
                 # Reset current count to 0 for next retry
-                # Decrement current_retries by 1
+                # Decrement remaining_attempts by 1
                 # Wait for sleep_timer before checking workflow statuses again (adjust value as needed)
                 logging.info(f"These workflows have yet to return a completed status: [{', '.join(workflow_ids)}]")
-                current_retries -= 1
+                remaining_attempts -= 1
                 current_running_workflow_count = 0
                 time.sleep(sleep_timer)
     logging.info("Workflow(s) submission and completion successful")


### PR DESCRIPTION
Increase wait time before we give up on a workflow and fail from about 11 minutes to about 15 minutes. I've seen that in successful test runs, workflows often take close to the 11 minutes to finish.