### PR TITLE
TSPS-195 add valid inputs to tsps create job request

### DIFF
--- a/e2e-test/tsps_e2e_test.py
+++ b/e2e-test/tsps_e2e_test.py
@@ -63,7 +63,9 @@ def run_imputation_pipeline(tsps_url, token):
             "id": f'{uuid.uuid4()}'
         },
         "pipelineVersion": "string",
-        "pipelineInputs": {}
+        "pipelineInputs": {
+            "multi_sample_vcf": "this/is/a/fake/file.vcf.gz"
+        }
     }
 
     uri = f"{tsps_url}/api/pipelines/v1/imputation_beagle"


### PR DESCRIPTION
Update the TSPS e2e test so that new input validation introduced in https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/75 won't cause the test to fail.

See ticket https://broadworkbench.atlassian.net/browse/TSPS-195