### PR TITLE
AJ-1791 - Log error if wds on cloned workspace fails to start

### DIFF
--- a/e2e-test/wds_azure_e2etest.py
+++ b/e2e-test/wds_azure_e2etest.py
@@ -52,7 +52,7 @@ def run_workspace_app_test(cbas, wds_upload, cbas_submit_workflow, test_cloning,
         clone_id, clone_name = clone_workspace(billing_project_name, workspace_name, header)
         wds_url = poll_for_app_url(clone_id, "WDS", "wds", azure_token, leo_url)
         if wds_url == "":
-            logging.error(f"wds errored out for cloned workspace {workspace_id}")
+            logging.error(f"wds errored out for cloned workspace {clone_id}")
         else:
             check_wds_data(wds_url, clone_id, "test", azure_token)
             # Once we've verified the cloned data is present, verify we can upload into the cloned workspace

--- a/e2e-test/wds_azure_e2etest.py
+++ b/e2e-test/wds_azure_e2etest.py
@@ -51,11 +51,14 @@ def run_workspace_app_test(cbas, wds_upload, cbas_submit_workflow, test_cloning,
     if test_cloning and upload_success:
         clone_id, clone_name = clone_workspace(billing_project_name, workspace_name, header)
         wds_url = poll_for_app_url(clone_id, "WDS", "wds", azure_token, leo_url)
-        check_wds_data(wds_url, clone_id, "test", azure_token)
-        # Once we've verified the cloned data is present, verify we can upload into the cloned workspace
-        # This tsv relies on the presence of the cloned data and also has more data types
-        clone_upload_success = upload_wds_data(wds_url, clone_id, "resources/all_data_types.tsv", "data", azure_token)
-        assert clone_upload_success
+        if wds_url == "":
+            logging.error(f"wds errored out for cloned workspace {workspace_id}")
+        else:
+            check_wds_data(wds_url, clone_id, "test", azure_token)
+            # Once we've verified the cloned data is present, verify we can upload into the cloned workspace
+            # This tsv relies on the presence of the cloned data and also has more data types
+            clone_upload_success = upload_wds_data(wds_url, clone_id, "resources/all_data_types.tsv", "data", azure_token)
+            assert clone_upload_success
         if delete_created_workspace:
             test_cleanup(billing_project_name, clone_name, azure_token)
 


### PR DESCRIPTION
Make sure the test errors with a correct error message if WDS in a cloned workspace failed to start.