### PR TITLE
TSPS-227 update TSPS API path

### DIFF
--- a/e2e-test/tsps_e2e_test.py
+++ b/e2e-test/tsps_e2e_test.py
@@ -47,7 +47,7 @@ def run_imputation_pipeline(tsps_url, token):
         }
     }
 
-    uri = f"{tsps_url}/api/pipelines/v1/imputation_beagle"
+    uri = f"{tsps_url}/api/pipelineruns/v1/imputation_beagle"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",
@@ -75,7 +75,7 @@ def poll_for_imputation_job(tsps_url, job_id, token):
 
     # waiting for 25 total minutes, initial 5 minutes then 20 intervals of 1 minute each
     poll_count = 20
-    uri = f"{tsps_url}/api/pipelines/v1/imputation_beagle/result/{job_id}"
+    uri = f"{tsps_url}/api/pipelineruns/v1/imputation_beagle/result/{job_id}"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",


### PR DESCRIPTION
In https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/87 we are changing the API endpoint path to create and get the result for a pipeline run, so we need to update the test to reflect that

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-227