### PR TITLE
AJ-1398 remove workflows from wds test

### DIFF
--- a/e2e-test/wds_azure_e2etest.py
+++ b/e2e-test/wds_azure_e2etest.py
@@ -9,23 +9,21 @@ azure_token = os.environ.get("AZURE_TOKEN")
 bee_name = os.environ.get("BEE_NAME")
 billing_project_name = os.environ.get("BILLING_PROJECT_NAME")
 #TODO: Take in arguments from the command line?
-cbas=False
 wds_upload=True
-cbas_submit_workflow=False
 test_cloning=False
 delete_created_workspace=True
 
-def run_workspace_app_test(cbas, wds_upload, cbas_submit_workflow, test_cloning, delete_created_workspace):
+def run_workspace_app_test(wds_upload, test_cloning, delete_created_workspace):
 
     workspace_manager_url, rawls_url, leo_url = setup(bee_name)
     header = {"Authorization": "Bearer " + azure_token};
 
     # create the workspace
-    workspace_id, workspace_name = create_workspace_with_cromwell_app(cbas, billing_project_name, azure_token)
+    workspace_id, workspace_name = create_workspace(billing_project_name, azure_token, rawls_url)
 
     # track to see when the workspace WDS is ready to upload data into them
     # sleep to allow apps to start up
-    if wds_upload or cbas_submit_workflow:
+    if wds_upload:
         logging.info("Sleeping for 30 seconds while apps start up")
         time.sleep(30)
     else:
@@ -40,12 +38,6 @@ def run_workspace_app_test(cbas, wds_upload, cbas_submit_workflow, test_cloning,
             logging.error(f"wds errored out for workspace {workspace_id}")
         else:
             upload_success = upload_wds_data(wds_url, workspace_id, "resources/test.tsv", "test", azure_token)
-
-    if cbas_submit_workflow:
-        # next trigger a workflow in each of the workspaces, at this time this doesnt monitor if this was succesful or not
-        # upload file needed for workflow to run
-        upload_success = upload_wds_data(wds_url, workspace_id, "resources/sraloadtest.tsv", "sraloadtest", azure_token)
-        submit_workflow_assemble_refbased(workspace_id, "resources/assemble_refbased.json", azure_token)
 
     # no point in testing cloning if upload didn't succeed in first place
     if test_cloning and upload_success:
@@ -68,4 +60,4 @@ def run_workspace_app_test(cbas, wds_upload, cbas_submit_workflow, test_cloning,
     print("TEST COMPLETE.")
 
 # Run create & clone wds test
-run_workspace_app_test(cbas,wds_upload,cbas_submit_workflow,True,delete_created_workspace)
+run_workspace_app_test(wds_upload,True,delete_created_workspace)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1398
When the wds test was originally written, it had flags for whether or not to run workflows with the expectation that those apps would also be tested.  Workflows instead wrote separate test files, leaving all the workflows-related flags unused in the wds test.  This PR removes this unused code and should not have any difference in behavior, and certainly should not affect any non-wds test.  For stewards of the other tests, please verify that your tests are not affected.