### PR TITLE
TSPS-246 teaspoons now takes camelCase inputs

### DIFF
--- a/e2e-test/tsps_e2e_test.py
+++ b/e2e-test/tsps_e2e_test.py
@@ -44,8 +44,8 @@ def run_imputation_pipeline(tsps_url, token):
         },
         "pipelineVersion": "string",
         "pipelineInputs": {
-            "multi_sample_vcf": "this/is/a/fake/file.vcf.gz",
-            "output_basename": "fake_basename"
+            "multiSampleVcf": "this/is/a/fake/file.vcf.gz",
+            "outputBasename": "fake_basename"
         }
     }
 


### PR DESCRIPTION
This PR https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/94 included a change of the user-provided input keys to teaspoons from snake_case to camelCase. here we update the teaspoons e2e test to reflect that change.