### PR TITLE
add secrets explicitly

### DIFF
--- a/.github/workflows/can-i-deploy.yaml
+++ b/.github/workflows/can-i-deploy.yaml
@@ -38,6 +38,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      PACT_BROKER_USERNAME:
+        description: 'The username to log into pact-broker'
+        required: true
+      PACT_BROKER_PASSWORD:
+        description: 'The password to log into pact-broker'
+        required: true
 
 env:
   PACT_BROKER_BASE_URL: 'https://pact-broker.dsp-eng-tools.broadinstitute.org'


### PR DESCRIPTION
Have to add the secrets explicitly, annoyingly, secrets: inheirit works fine.... if both projects are in broadinstitute, but dies silently if databiosphere tries to use it. (it doesn't error, it just doesn't pass the secrets, which of course breaks the flow)