### PR TITLE
TSPS-281 Create Teaspoons Imputation Service workspace creation script for GCP

### DIFF
--- a/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
+++ b/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
@@ -112,12 +112,7 @@ if tsps_sa_email:
                     tsps_sa_email, user_token)
 
 
-# empty wdl:
-# wdl_url = "https://github.com/DataBiosphere/terra-scientific-pipelines-service/blob/main/pipelines/testing/ImputationBeagleEmpty.wdl"
-# working wdl:
-wdl_url = "https://github.com/broadinstitute/warp/blob/TSPS-183_mma_beagle_imputation_hg38/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl"
 
-logging.info(f"Adding {wdl_url} to workspace")
 
 # import imputation method
 wdl_namespace = billing_project_name
@@ -158,5 +153,7 @@ outputs_dict = {
     f"{wdl_name}.imputed_multi_sample_vcf": "this.imputed_multi_sample_vcf",
     f"{wdl_name}.imputed_multi_sample_vcf_index": "this.imputed_multi_sample_vcf_index"
   }
+
+logging.info(f"Adding {wdl_name} ({method_definition_dict['methodPath']}) to workspace")
 
 add_wdl_to_gcp_workspace(billing_project_name, workspace_name, wdl_namespace, wdl_name, method_definition_dict, root_entity_type, inputs_dict, outputs_dict, firecloud_orch_url, user_token)

--- a/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
+++ b/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
@@ -125,20 +125,20 @@ root_entity_type = "imputation_beagle"
 
 use_empty_wdl = args.use_empty_wdl
 if use_empty_wdl:
-    version_or_branch = "0.0.100"
+    tag_or_branch = "0.0.100"
     method_definition_dict = {
-        "methodUri": f"dockstore://github.com%2FDataBiosphere%2Fterra-scientific-pipelines-service%2FImputationBeagleEmpty/{version_or_branch}",
+        "methodUri": f"dockstore://github.com%2FDataBiosphere%2Fterra-scientific-pipelines-service%2FImputationBeagleEmpty/{tag_or_branch}",
         "sourceRepo": "dockstore",
         "methodPath": "github.com/DataBiosphere/terra-scientific-pipelines-service/ImputationBeagleEmpty",
-        "methodVersion": version_or_branch
+        "methodVersion": tag_or_branch
     }
 else:
-    version_or_branch = "TSPS-183_mma_beagle_imputation_hg38"
+    tag_or_branch = "TSPS-183_mma_beagle_imputation_hg38"
     method_definition_dict = {
-        "methodUri": f"dockstore://github.com%2Fbroadinstitute%2Fwarp%2FImputationBeagle/{version_or_branch}",
+        "methodUri": f"dockstore://github.com%2Fbroadinstitute%2Fwarp%2FImputationBeagle/{tag_or_branch}",
         "sourceRepo": "dockstore",
         "methodPath": "github.com/broadinstitute/warp/ImputationBeagle",
-        "methodVersion": version_or_branch
+        "methodVersion": tag_or_branch
     }
 
 input_keys = [

--- a/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
+++ b/e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py
@@ -1,0 +1,162 @@
+import argparse
+import requests
+import logging
+import sys
+import os
+ 
+# getting the name of the directory
+# where this file is present.
+current = os.path.dirname(os.path.realpath(__file__))
+ 
+# Getting the parent directory name
+# where the current directory is present.
+grandparent = os.path.dirname(os.path.dirname(current))
+ 
+# adding the parent directory to 
+# the sys.path.
+sys.path.append(grandparent)
+ 
+# importing
+from workspace_helper import create_gcp_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run e2e test for TSPS/Imputation service')
+    parser.add_argument('-t', '--user_token', required=False,
+        help='token for user to authenticate Terra API calls')
+    parser.add_argument('-m', '--tsps_sa_email', required=False,
+        help='email of tsps service account to share workspace/billing project with')
+    parser.add_argument('--use_real_wdl', action='store_true',
+        help='whether to import the real ImputationBeagle wdl or the ImputationBeagleEmpty wdl for testing')
+    parser.add_argument('-e', '--env', required=False, default='dev',
+        help='environment. e.g. `dev` (default) or bee name `terra-marymorg`')
+    parser.add_argument('-p', '--billing_project', required=False,
+        help='billing project to create workspace in')
+    parser.add_argument('-w', '--workspace_name', required=False,
+        help='name of workspace to be created, if left blank will be auto-generated')
+    parser.add_argument('-b', '--is-bee', action='store_true',
+        help='flag that the environment is a bee')
+    args = parser.parse_args()
+
+
+# Setup configuration
+user_token = args.user_token
+
+if args.is_bee:
+    env_string = f"{args.env}.bee.envs-terra.bio"
+else:
+    env_string = f"dsde-{args.env}.broadinstitute.org"
+
+billing_project_name = args.billing_project
+workspace_name = args.workspace_name
+tsps_sa_email = args.tsps_sa_email
+
+rawls_url = f"https://rawls.{env_string}"
+firecloud_orch_url = f"https://firecloud-orchestration.{env_string}" # this doesn't work for BEEs; BEES it's firecloudorch.{env_string}
+tsps_url = f"https://tsps.{env_string}"
+
+# configure logging format
+LOG_FORMAT = "%(asctime)s %(levelname)-8s %(message)s"
+LOG_LEVEL = "INFO"
+LOG_DATEFORMAT = "%Y-%m-%d %H:%M:%S"
+logging.basicConfig(
+    format=LOG_FORMAT,
+    level=getattr(logging, LOG_LEVEL),
+    datefmt=LOG_DATEFORMAT,
+)
+
+
+# Check whether workspace exists
+def workspace_exists(billing_project_name, workspace_name, rawls_url, token):
+    # returns workspace_id if workspace exists, or None if not
+
+    rawls_workspace_api = f"{rawls_url}/api/workspaces/{billing_project_name}/{workspace_name}"
+    
+    header = {
+        "Authorization": "Bearer " + token,
+        "accept": "application/json"
+    }
+
+    response = requests.get(url=rawls_workspace_api, headers=header)
+
+    status_code = response.status_code
+
+    if status_code != 200:
+        return None
+    
+    response_json = response.json()
+    return response_json['workspace']
+
+
+# ---------------------- Start TSPS Imputation Workspace Setup ----------------------
+
+logging.info("Starting TSPS imputation workspace setup...")
+
+if workspace_name == "":
+    workspace_id = None
+else:
+    # Check if workspace exists already
+    logging.info(f"Checking if workspace {billing_project_name}/{workspace_name} exists...")
+    workspace_info = workspace_exists(billing_project_name, workspace_name, rawls_url, user_token)
+    logging.info(f"Workspace {'already exists' if workspace_info else 'does not yet exist'}")
+
+if not(workspace_info):
+    # Create workspace
+    logging.info("Creating workspace...")
+    workspace_id, workspace_name = create_gcp_workspace(billing_project_name, user_token, rawls_url, workspace_name)
+
+# share created workspace with the tsps service account
+if tsps_sa_email:
+    logging.info(f"sharing workspace with {tsps_sa_email}")
+    share_workspace_grant_owner(firecloud_orch_url, billing_project_name, workspace_name,
+                    tsps_sa_email, user_token)
+
+
+# empty wdl:
+# wdl_url = "https://github.com/DataBiosphere/terra-scientific-pipelines-service/blob/main/pipelines/testing/ImputationBeagleEmpty.wdl"
+# working wdl:
+wdl_url = "https://github.com/broadinstitute/warp/blob/TSPS-183_mma_beagle_imputation_hg38/pipelines/broad/arrays/imputation_beagle/ImputationBeaglePreChunk.wdl"
+
+logging.info(f"Adding {wdl_url} to workspace")
+
+# import imputation method
+wdl_namespace = billing_project_name
+root_entity_type = "imputation_beagle"
+
+use_real_wdl = True
+if use_real_wdl:
+    wdl_name = "ImputationBeagle"
+    version_or_branch = "TSPS-183_mma_beagle_imputation_hg38"
+    method_definition_dict = {
+        "methodUri": f"dockstore://github.com%2Fbroadinstitute%2Fwarp%2FImputationBeagle/{version_or_branch}",
+        "sourceRepo": "dockstore",
+        "methodPath": "github.com/broadinstitute/warp/ImputationBeagle",
+        "methodVersion": version_or_branch
+    }
+else:
+    wdl_name = "ImputationBeagleEmpty"
+    version_or_branch = "0.0.100"
+    method_definition_dict = {
+        "methodUri": f"dockstore://github.com%2FDataBiosphere%2Fterra-scientific-pipelines-service%2FImputationBeagleEmpty/{version_or_branch}",
+        "sourceRepo": "dockstore",
+        "methodPath": "github.com/DataBiosphere/terra-scientific-pipelines-service/ImputationBeagleEmpty",
+        "methodVersion": version_or_branch
+
+    }
+
+inputs_dict = {
+    f"{wdl_name}.contigs": "this.contigs",
+    f"{wdl_name}.genetic_maps_path": "this.genetic_maps_path",
+    f"{wdl_name}.multi_sample_vcf": "this.multi_sample_vcf",
+    f"{wdl_name}.output_basename": "this.output_basename",
+    f"{wdl_name}.ref_dict": "this.ref_dict",
+    f"{wdl_name}.reference_panel_path_prefix": "this.reference_panel_path_prefix",
+  }
+
+outputs_dict = {
+    f"{wdl_name}.chunks_info": "this.chunks_info",
+    f"{wdl_name}.imputed_multi_sample_vcf": "this.imputed_multi_sample_vcf",
+    f"{wdl_name}.imputed_multi_sample_vcf_index": "this.imputed_multi_sample_vcf_index"
+  }
+
+add_wdl_to_gcp_workspace(billing_project_name, workspace_name, wdl_namespace, wdl_name, method_definition_dict, root_entity_type, inputs_dict, outputs_dict, firecloud_orch_url, user_token)

--- a/e2e-test/workspace_helper.py
+++ b/e2e-test/workspace_helper.py
@@ -183,7 +183,7 @@ def share_workspace_grant_owner(orch_url, billing_project_name, workspace_name, 
     if status_code != 200:
         raise Exception(response.text)
 
-    logging.info(f"Successfully shared workspace {workspace_name} with {email_to_share}")
+    logging.info(f"Successfully shared workspace {workspace_name} with {email_to_share} as OWNER")
 
 
 # ADD WDL TO GCP WORKSPACE ACTION

--- a/e2e-test/workspace_helper.py
+++ b/e2e-test/workspace_helper.py
@@ -109,7 +109,7 @@ def create_gcp_workspace(billing_project_name, token, rawls_url, workspace_name 
 
             logging.info(f"Successfully created workspace '{workspace_name}' in billing project '{billing_project_name}'.")
 
-            return data, data['name']
+            return data['name']
 
         except Exception as e:
             logging.info(f"ERROR workspace creation for '{workspace_name}' in billing project '{billing_project_name}'. Error: {e}")

--- a/e2e-test/workspace_helper.py
+++ b/e2e-test/workspace_helper.py
@@ -90,19 +90,29 @@ def create_gcp_workspace(billing_project_name, token, rawls_url, workspace_name 
 
             # example json that is returned by request:
             # {
-            #   "attributes": {},
-            #   "authorizationDomain": [],
-            #   "bucketName": "",
-            #   "createdBy": "yulialovesterra@gmail.com",
-            #   "createdDate": "2023-08-03T20:10:59.116Z",
-            #   "googleProject": "",
-            #   "isLocked": False,
-            #   "lastModified": "2023-08-03T20:10:59.116Z",
-            #   "name": "api-workspace-1",
-            #   "namespace": "yuliadub-test2",
-            #   "workspaceId": "ac466322-2325-4f57-895d-fdd6c3f8c7ad",
-            #   "workspaceType": "mc",
-            #   "workspaceVersion": "v2"
+            # "attributes": {},
+            # "authorizationDomain": [
+            #     {
+            #     "membersGroupName": "example-auth-domain-group"
+            #     }
+            # ],
+            # "billingAccount": "billingAccounts/0A0A0A-0A0A0A-0A0A0A",
+            # "bucketName": "fc-secure-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            # "cloudPlatform": "Gcp",
+            # "completedCloneWorkspaceFileTransfer": "2024-09-13T12:59:15.795Z",
+            # "createdBy": "yulialovesterra@gmail.com",
+            # "createdDate": "2024-09-13T12:59:15.795Z",
+            # "googleProject": "terra-a1a1a1a1",
+            # "googleProjectNumber": "101010101010",
+            # "isLocked": false,
+            # "lastModified": "2024-09-13T12:59:15.795Z",
+            # "name": "workspace-name",
+            # "namespace": "terra-project-name",
+            # "state": "Ready",
+            # "workflowCollectionName": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            # "workspaceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            # "workspaceType": "rawls",
+            # "workspaceVersion": "v2"
             # }
             workspace_response_json = workspace_response.json()
             data = json.loads(json.dumps(workspace_response_json))


### PR DESCRIPTION
this new workspace creation script:
- works in any environment (except BEEs)
- creates a GCP workspace with enhanced logging + auth domain
- shares with Teaspoons SA (as owner) if one is included in script input params
- allows sharing with other accounts (e.g. teaspoons developers group)
- imports WDL - either the real WDL or empty WDL, ultimately named ImputationBeagle - with config set up as much as possible

Example command in dev:
```python e2e-test/resources/tsps/tsps_gcp_set_up_control_workspace.py -t `gcloud auth print-access-token marymorg.dev@gmail.com` -e dev -p teaspoons-imputation-dev -w test-imputation-workspace-dev-1 -a teaspoons-imputation-workspace-auth-domain -s teaspoons-developers-dev@dev.test.firecloud.org --use-empty-wdl```

ticket: https://broadworkbench.atlassian.net/browse/TSPS-281