### PR TITLE
AJ-2027: update actions in upload_test_results_to_biquery

### DIFF
--- a/.github/workflows/upload_test_results_to_biquery.yaml
+++ b/.github/workflows/upload_test_results_to_biquery.yaml
@@ -61,13 +61,13 @@ jobs:
       id-token: 'write'
     steps:
       - name: "Checkout dsp-reusable-workflows"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.target-branch }}
           repository: broadinstitute/dsp-reusable-workflows
           path: ${{ env.CHECKOUT_PATH }}
       - name: Setup Python # Set Python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Auth to GCP
         if: ${{ steps.download-artifact-legacy-v3.outcome == 'success' || steps.download-artifact.outcome == 'success' }}
         id: 'auth'
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'


### PR DESCRIPTION
updates github actions to avoid deprecation warnings.