### PR TITLE
fix admin piplines api call in teaspoons e2e test

### DIFF
--- a/e2e-test/tsps_gcp_e2e_test.py
+++ b/e2e-test/tsps_gcp_e2e_test.py
@@ -19,7 +19,7 @@ def update_imputation_pipeline_workspace(tsps_url, workspace_project, workspace_
         "wdlMethodVersion": wdl_method_version
     }
 
-    uri = f"{tsps_url}/api/admin/v1/pipeline/array_imputation"
+    uri = f"{tsps_url}/api/admin/v1/pipelines/array_imputation"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",


### PR DESCRIPTION
to address the test failure here - https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/11943565231/job/33293144545

because of the changes made in https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/162/files