### PR TITLE
TSPS-370 update API calls to match latest changes

### DIFF
--- a/e2e-test/teaspoons_gcp_e2e_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_test.py
@@ -19,7 +19,7 @@ def update_imputation_pipeline_workspace(teaspoons_url, workspace_project, works
         "wdlMethodVersion": wdl_method_version
     }
 
-    uri = f"{teaspoons_url}/api/admin/v1/pipelines/array_imputation"
+    uri = f"{teaspoons_url}/api/admin/v1/pipelines/array_imputation/0"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",
@@ -72,7 +72,7 @@ def start_imputation_pipeline(jobId, teaspoons_url, token):
         }
     }
 
-    uri = f"{teaspoons_url}/api/pipelineruns/v1/array_imputation/start"
+    uri = f"{teaspoons_url}/api/pipelineruns/v1/start"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",


### PR DESCRIPTION
should fix the e2e test with the changes to not requiring [pipeline name for start ](https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/170) and [version changes to the admin endpoint](https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/171)

this should be merged after those are merged