### PR TITLE
TSPS-388 Teaspoons e2e test: move description input from start endpoint to prepare endpoint

### DIFF
--- a/e2e-test/teaspoons_gcp_e2e_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_test.py
@@ -43,7 +43,8 @@ def prepare_imputation_pipeline(teaspoons_url, token):
         "pipelineInputs": {
             "multiSampleVcf": "this/is/a/fake/file.vcf.gz",
             "outputBasename": "fake_basename"
-        }
+        },
+        "description": f"e2e test run"
     }
 
     uri = f"{teaspoons_url}/api/pipelineruns/v1/prepare"
@@ -67,7 +68,6 @@ def prepare_imputation_pipeline(teaspoons_url, token):
 # run imputation beagle pipeline
 def start_imputation_pipeline(jobId, teaspoons_url, token):
     request_body = {
-        "description": f"e2e test run for jobId {jobId}",
         "jobControl": {
             "id": f'{jobId}'
         }


### PR DESCRIPTION
We moved the user-provided description input from the `start` endpoint payload to the `prepare` endpoint payload. This PR makes that update in the e2e test.

Teaspoons PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/180
Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-388