### PR TITLE
TSPS-388 redo: move description from start to prepare endpoint

### DIFF
--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -49,7 +49,8 @@ def prepare_imputation_pipeline(teaspoons_url, token):
         "pipelineInputs": {
             "multiSampleVcf": "this/is/a/fake/file.vcf.gz",
             "outputBasename": "fake_basename"
-        }
+        },
+        "description": f"e2e test run"
     }
 
     uri = f"{teaspoons_url}/api/pipelineruns/v1/prepare"
@@ -73,7 +74,6 @@ def prepare_imputation_pipeline(teaspoons_url, token):
 # run imputation beagle pipeline
 def start_imputation_pipeline(jobId, teaspoons_url, token):
     request_body = {
-        "description": f"e2e test run for jobId {jobId}",
         "jobControl": {
             "id": f'{jobId}'
         }

--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -50,7 +50,7 @@ def prepare_imputation_pipeline(teaspoons_url, token):
             "multiSampleVcf": "this/is/a/fake/file.vcf.gz",
             "outputBasename": "fake_basename"
         },
-        "description": f"e2e test run"
+        "description": "e2e test run"
     }
 
     uri = f"{teaspoons_url}/api/pipelineruns/v1/prepare"


### PR DESCRIPTION
This is a redo of this PR: https://github.com/broadinstitute/dsp-reusable-workflows/pull/60
Which was accidentally reverted in this PR: https://github.com/broadinstitute/dsp-reusable-workflows/pull/59/files#diff-9709ae917f41eaa6a096c695fd5356a292dd5ef60ed82b1eeaf8851330a7dcd5

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-388