### PR TITLE
Teaspoons CLI e2e test: Pin poetry version for fix for poetry 2.0.0 bug

### DIFF
--- a/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
@@ -55,6 +55,8 @@ jobs:
       
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.8.5
 
       - name: Generate OAuth2 2.0 access token for Terra user
         id: obtain_user_token


### PR DESCRIPTION
Poetry 2.0.0 update broke our e2e test; the workaround specified [here](https://github.com/python-poetry/poetry/issues/9961) and implemented by us [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/25) ended up breaking our build. So for now we'll pin poetry to version 1.8.5 (the last working version we had before the update to 2.0.0) until poetry fixes this bug.

Test run: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/actions/runs/12639177524

Companion PR in CLI repo to revert the previous workaround, which broke our build. https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/26