### PR TITLE
TSPS-346 Update Teaspoons CLI e2e test to use arbitrary pipeline input specification

### DIFF
--- a/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
@@ -123,8 +123,7 @@ jobs:
 
           touch "$INPUT_FILE"
           echo "Submitting new job"
-          INPUTS_JSON={\"multiSampleVcf\":\"$INPUT_FILE\",\"outputBasename\":\"$OUTPUT_BASENAME\"}
-          SUBMIT_OUTPUT="$(poetry run terralab submit array_imputation --inputs $INPUTS_JSON 2>&1)"
+          SUBMIT_OUTPUT="$(poetry run terralab submit array_imputation --multiSampleVcf $INPUT_FILE --outputBasename $OUTPUT_BASENAME 2>&1)"
           JOB_ID="$(echo "$SUBMIT_OUTPUT" | tail -n1 | grep -o '[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}')"
           [ -n "$JOB_ID" ] || { echo "Failed to extract job ID"; exit 1; }
           echo "Created job with ID $JOB_ID"


### PR DESCRIPTION
We changed the way users specify inputs to the Teaspoons CLI (terralab). This PR makes that update in our e2e test.

Teaspoons CLI PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/23

Test run: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/actions/runs/12695336306