### PR TITLE
CORE-205: remove download-artifact@v3

### DIFF
--- a/.github/workflows/upload_test_results_to_biquery.yaml
+++ b/.github/workflows/upload_test_results_to_biquery.yaml
@@ -78,24 +78,13 @@ jobs:
           pip install --upgrade google-cloud-bigquery
       - name: Download Artifact
         id: download-artifact
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact }}
           # gotta put this where the script will be run from
           path: ${{ env.CHECKOUT_PATH }}${{ env.SCRIPT_PATH }}${{ env.ARTIFACT_PATH }}
-      # try using old v3 artifacts if newest fails
-      - name: Download Artifact Legacy v3
-        id: download-artifact-legacy-v3
-        if: ${{ steps.download-artifact.outcome == 'failure' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ inputs.artifact }}
-          # gotta put this where the script will be run from
-          path: ${{ env.CHECKOUT_PATH }}${{ env.SCRIPT_PATH }}${{ env.ARTIFACT_PATH }}
       - name: Auth to GCP
-        if: ${{ steps.download-artifact-legacy-v3.outcome == 'success' || steps.download-artifact.outcome == 'success' }}
+        if: ${{ steps.download-artifact.outcome == 'success' }}
         id: 'auth'
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
`download-artifact@v3` no longer works: https://github.com/marketplace/actions/download-a-build-artifact

This PR removes the reference to it.