### PR TITLE
TSPS-434 ping sam before running teaspoons e2e tests

### DIFF
--- a/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
+++ b/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
@@ -1,6 +1,6 @@
 from workspace_helper import create_gcp_workspace, delete_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
 from helper import create_gcp_billing_project, delete_gcp_billing_project
-from teaspoons_helper import create_and_populate_terra_group, update_imputation_pipeline_workspace
+from teaspoons_helper import create_and_populate_terra_group, update_imputation_pipeline_workspace, ping_until_200_with_timeout
 
 import os
 import logging
@@ -23,6 +23,7 @@ workspace_name = os.environ.get("WORKSPACE_NAME")
 rawls_url = f"https://rawls.{env_string}"
 firecloud_orch_url = f"https://firecloudorch.{env_string}"
 teaspoons_url = f"https://teaspoons.{env_string}"
+sam_url = f"https://sam.{env_string}"
 
 wdl_method_version = os.environ.get("WDL_METHOD_VERSION")
 
@@ -40,6 +41,10 @@ logging.basicConfig(
 try:
     logging.info("Starting Teaspoons GCP E2E test...")
     logging.info(f"billing project: {billing_project_name}, env_string: {env_string}")
+
+    logging.info(f"checking if Sam is pingable")
+    ping_until_200_with_timeout(f"{sam_url}/liveness", 300)
+    ping_until_200_with_timeout(f"{sam_url}/status", 300)
 
     # Create Terra billing project
     logging.info("Creating billing project...")

--- a/e2e-test/teaspoons_gcp_e2e_service_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_service_test.py
@@ -3,7 +3,7 @@ from helper import create_gcp_billing_project, delete_gcp_billing_project
 from teaspoons_helper import (
     create_and_populate_terra_group, update_imputation_pipeline_workspace, query_for_user_quota_consumed, 
     prepare_imputation_pipeline, upload_file_with_signed_url, start_imputation_pipeline, poll_for_imputation_job,
-    download_with_signed_url
+    download_with_signed_url, ping_until_200_with_timeout
 )
 
 import os
@@ -29,6 +29,7 @@ workspace_name = ""
 rawls_url = f"https://rawls.{env_string}"
 firecloud_orch_url = f"https://firecloudorch.{env_string}"
 teaspoons_url = f"https://teaspoons.{env_string}"
+sam_url = f"https://sam.{env_string}"
 
 wdl_method_version = os.environ.get("WDL_METHOD_VERSION")
 
@@ -47,6 +48,10 @@ found_exception = False
 try:
     logging.info("Starting Teaspoons GCP E2E test...")
     logging.info(f"billing project: {billing_project_name}, env_string: {env_string}")
+
+    logging.info(f"checking if Sam is pingable")
+    ping_until_200_with_timeout(f"{sam_url}/liveness", 300)
+    ping_until_200_with_timeout(f"{sam_url}/status", 300)
 
     # Create Terra billing project
     logging.info("Creating billing project...")

--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -233,3 +233,18 @@ def add_member_to_terra_group(orch_url, group_name, email_address, role, token):
         raise Exception(response.text)
     
     logging.info(f"added {email_address} as {role} to Terra group {group_name}")
+
+
+# sometimes we want to check if a service is pingable before running our e2e test due to some transient
+# issues we've been seeing.
+def ping_until_200_with_timeout(url, timeout_seconds=300):
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                return
+        except requests.exceptions.ConnectionError:
+            logging.warning(f"URL {url} not reachable")
+        time.sleep(30)
+    raise Exception(f"Timed out waiting for {url} to return 200")


### PR DESCRIPTION
We are seeing some transient failures when running our e2e tests where rawls/orch cant talk to sam due to unknown host exceptions.  We're seeing if pinging sam before running our tests can help with this issue.