### PR TITLE
TSPS-434 adding a sleep to the start of the teaspoons e2e test to avoid unknown host exceptions

### DIFF
--- a/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
+++ b/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
@@ -1,3 +1,5 @@
+import time
+
 from workspace_helper import create_gcp_workspace, delete_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
 from helper import create_gcp_billing_project, delete_gcp_billing_project
 from teaspoons_helper import create_and_populate_terra_group, update_imputation_pipeline_workspace, ping_until_200_with_timeout
@@ -45,6 +47,10 @@ try:
     logging.info(f"checking if Sam is pingable")
     ping_until_200_with_timeout(f"{sam_url}/liveness", 300)
     ping_until_200_with_timeout(f"{sam_url}/status", 300)
+
+    logging.info("sleeping for 5 minutes to let the environment settle.  This is due to transient issues with "
+                 "uknownhost exceptions that we've seen with past test runs")
+    time.sleep(300)
 
     # Create Terra billing project
     logging.info("Creating billing project...")

--- a/e2e-test/teaspoons_gcp_e2e_service_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_service_test.py
@@ -1,3 +1,5 @@
+import time
+
 from workspace_helper import create_gcp_workspace, delete_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
 from helper import create_gcp_billing_project, delete_gcp_billing_project
 from teaspoons_helper import (
@@ -52,6 +54,10 @@ try:
     logging.info(f"checking if Sam is pingable")
     ping_until_200_with_timeout(f"{sam_url}/liveness", 300)
     ping_until_200_with_timeout(f"{sam_url}/status", 300)
+
+    logging.info("sleeping for 5 minutes to let the environment settle.  This is due to transient issues with "
+                 "uknownhost exceptions that we've seen with past test runs")
+    time.sleep(300)
 
     # Create Terra billing project
     logging.info("Creating billing project...")


### PR DESCRIPTION
We've been seen an uptick in transient failures with our e2e test due to unknown host exceptions.  We had a discussion in [slack](https://broadinstitute.slack.com/archives/C07QQ3L0AHX/p1738604418720059) and for now this seems like the most reasonable way forward.