### PR TITLE
update array_imputation to version 1 to match service changes

### DIFF
--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -25,7 +25,7 @@ def update_imputation_pipeline_workspace(teaspoons_url, workspace_project, works
         "toolVersion": wdl_method_version
     }
 
-    uri = f"{teaspoons_url}/api/admin/v1/pipelines/array_imputation/0"
+    uri = f"{teaspoons_url}/api/admin/v1/pipelines/array_imputation/1"
     headers = {
         "Authorization": f"Bearer {token}",
         "accept": "application/json",
@@ -45,7 +45,7 @@ def prepare_imputation_pipeline(teaspoons_url, token):
     request_body = {
         "jobId": f'{uuid.uuid4()}',
         "pipelineName": "array_imputation",
-        "pipelineVersion": 0,
+        "pipelineVersion": 1,
         "pipelineInputs": {
             "multiSampleVcf": "this/is/a/fake/file.vcf.gz",
             "outputBasename": "fake_basename"


### PR DESCRIPTION
This is necessary for changes made to teaspoons in https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/207 to the version of the array_imputation version.  I think these are the only places that need to change