### PR TITLE
TSPS-508 update teaspoons e2e test to work with 0 default quota pipelines

### DIFF
--- a/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
@@ -87,7 +87,7 @@ jobs:
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
           USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
-          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
+          USER_EMAIL: 'hermione.owner@test.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
           WORKSPACE_NAME: 'teaspoons_e2e_cli_test_workspace'

--- a/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
@@ -86,6 +86,8 @@ jobs:
           BEE_NAME: ${{ inputs.bee-name }}
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
+          USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
+          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
           WORKSPACE_NAME: 'teaspoons_e2e_cli_test_workspace'

--- a/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_cli_tests.yaml
@@ -87,7 +87,7 @@ jobs:
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
           USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
-          USER_EMAIL: 'hermione.owner@test.firecloud.org'
+          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
           WORKSPACE_NAME: 'teaspoons_e2e_cli_test_workspace'

--- a/.github/workflows/run_teaspoons_e2e_service_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_service_tests.yaml
@@ -65,7 +65,7 @@ jobs:
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
           USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
-          USER_EMAIL: 'hermione.owner@test.firecloud.org'
+          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
         run: |

--- a/.github/workflows/run_teaspoons_e2e_service_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_service_tests.yaml
@@ -65,6 +65,7 @@ jobs:
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
           USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
+          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
         run: |

--- a/.github/workflows/run_teaspoons_e2e_service_tests.yaml
+++ b/.github/workflows/run_teaspoons_e2e_service_tests.yaml
@@ -65,7 +65,7 @@ jobs:
           BILLING_PROJECT_NAME: ${{ inputs.billing-project-name }}
           BILLING_ACCOUNT_NAME: 'billingAccounts/00708C-45D19D-27AAFA'
           USER_TOKEN: ${{ steps.obtain_user_token.outputs.access_token }}
-          USER_EMAIL: 'hermione.owner@quality.firecloud.org'
+          USER_EMAIL: 'hermione.owner@test.firecloud.org'
           ADMIN_TOKEN: ${{ steps.obtain_admin_user_token.outputs.access_token }}
           WDL_METHOD_VERSION: ${{ inputs.wdl-method-version }}
         run: |

--- a/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
+++ b/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
@@ -2,7 +2,8 @@ import time
 
 from workspace_helper import create_gcp_workspace, delete_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
 from helper import create_gcp_billing_project, delete_gcp_billing_project
-from teaspoons_helper import create_and_populate_terra_group, update_imputation_pipeline_workspace, ping_until_200_with_timeout
+from teaspoons_helper import create_and_populate_terra_group, update_imputation_pipeline_workspace, \
+    ping_until_200_with_timeout, query_for_user_quota_consumed, update_quota_limit_for_user
 
 import os
 import logging
@@ -11,6 +12,8 @@ import logging
 # Setup configuration
 # The environment variables are injected as part of the e2e test setup which does not pass in any args
 admin_token = os.environ.get("ADMIN_TOKEN") # admin user who has access to the terra billing project
+user_token = os.environ.get("USER_TOKEN") # the user who will kick off the teaspoons job
+user_email = os.environ.get("USER_EMAIL") # the user we will want to increase quota_limit for
  
 # e2e test is using the teaspoons qa service account
 teaspoons_sa_email = "teaspoons-qa@broad-dsde-qa.iam.gserviceaccount.com"
@@ -105,8 +108,11 @@ try:
     logging.info("updating imputation workspace info")
     update_imputation_pipeline_workspace(teaspoons_url, billing_project_name, workspace_name, wdl_method_version, admin_token)
 
-    logging.info("sleeping for 5 minutes to see if this addresses seemingly transient issues with batch")
-    time.sleep(300)
+    # query for user quota consumed before running pipeline, expect the default of 0
+    assert 0 == query_for_user_quota_consumed(teaspoons_url, user_token)
+    
+    # update user quota limit to 2500
+    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 2500)
 
     logging.info("SETUP COMPLETE")
 

--- a/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
+++ b/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
@@ -113,7 +113,7 @@ try:
     
     # update user quota limit to 2500
     update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 2500)
-
+    
     logging.info("SETUP COMPLETE")
 
 except Exception as e:

--- a/e2e-test/teaspoons_gcp_e2e_service_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_service_test.py
@@ -3,9 +3,9 @@ import time
 from workspace_helper import create_gcp_workspace, delete_workspace, share_workspace_grant_owner, add_wdl_to_gcp_workspace
 from helper import create_gcp_billing_project, delete_gcp_billing_project
 from teaspoons_helper import (
-    create_and_populate_terra_group, update_imputation_pipeline_workspace, query_for_user_quota_consumed, 
+    create_and_populate_terra_group, update_imputation_pipeline_workspace, query_for_user_quota_consumed,
     prepare_imputation_pipeline, upload_file_with_signed_url, start_imputation_pipeline, poll_for_imputation_job,
-    download_with_signed_url, ping_until_200_with_timeout
+    download_with_signed_url, ping_until_200_with_timeout, update_quota_limit_for_user
 )
 
 import os
@@ -17,6 +17,7 @@ import logging
 # The environment variables are injected as part of the e2e test setup which does not pass in any args
 admin_token = os.environ.get("ADMIN_TOKEN") # admin user who has access to the terra billing project
 user_token = os.environ.get("USER_TOKEN") # the user who will kick off the teaspoons job
+user_email = os.environ.get("USER_EMAIL") # the user we will want to increase quota_limit for
  
 # e2e test is using the teaspoons qa service account
 teaspoons_sa_email = "teaspoons-qa@broad-dsde-qa.iam.gserviceaccount.com"
@@ -115,8 +116,8 @@ try:
     # query for user quota consumed before running pipeline, expect the default of 0
     assert 0 == query_for_user_quota_consumed(teaspoons_url, user_token)
 
-    logging.info("sleeping for 5 minutes to see if this addresses seemingly transient issues with batch")
-    time.sleep(300)
+    # update user quota limit to 2500
+    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 2500)
 
     # prepare teaspoons imputation pipeline run
     logging.info("preparing imputation pipeline run")

--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -248,3 +248,43 @@ def ping_until_200_with_timeout(url, timeout_seconds=300):
             logging.warning(f"URL {url} not reachable")
         time.sleep(30)
     raise Exception(f"Timed out waiting for {url} to return 200")
+
+# update the quota limit for a user for the array_imputation_pipeline
+def update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, new_quota_limit):
+
+    uri = f"{sam_url}/api/admin/v1/user/email/{user_email}"
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "accept": "application/json",
+        "Content-Type": "application/json"
+    }
+
+    response = requests.get(uri, headers=headers)
+    status_code = response.status_code
+
+    if status_code != 200:
+        raise Exception(response.text)
+
+    logging.info(f"Successfully retrieved user info for {user_email}")
+
+    # parse the response to get the user ID
+    response = json.loads(response.text)
+    user_id = response['userInfo']['userSubjectId']
+
+    uri = f"{teaspoons_url}/api/admin/v1/quotas/array_imputation/{user_id}'"
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "accept": "application/json",
+        "Content-Type": "application/json"
+    }
+
+    request_body = {
+        "quotaLimit": new_quota_limit
+    }
+
+    response = requests.patch(uri, headers=headers, json=request_body)
+    status_code = response.status_code
+    if status_code != 200:
+        raise Exception(response.text)
+
+    logging.info(f"Successfully updated quota for user {user_email} to {new_quota_limit}")

--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -271,7 +271,7 @@ def update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email,
     response = json.loads(response.text)
     user_id = response['userInfo']['userSubjectId']
 
-    uri = f"{teaspoons_url}/api/admin/v1/quotas/array_imputation/{user_id}'"
+    uri = f"{teaspoons_url}/api/admin/v1/quotas/array_imputation/{user_id}"
     headers = {
         "Authorization": f"Bearer {admin_token}",
         "accept": "application/json",

--- a/e2e-test/teaspoons_helper.py
+++ b/e2e-test/teaspoons_helper.py
@@ -152,7 +152,7 @@ def query_for_user_quota_consumed(teaspoons_url, token):
     if status_code != 200:
         raise Exception(response.text)
 
-    logging.info(f"Successfully retried user quota")
+    logging.info(f"Successfully retrieved user quota")
     response = json.loads(response.text)
 
     return response['quotaConsumed']


### PR DESCRIPTION
Due to changes made in https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/223 we need to update our test to not expect users to have some non zero default quota when submitting a pipelines.  This updates the service and cli e2e tests to make it work

This should be merged before the service PR

Example GHA running successfully with these changes and service changes made in previously linked PR
https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15354167655/job/43209819021