### PR TITLE
TSPS-580 Set array_imputation default quota to 2500 for public release

### DIFF
--- a/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
+++ b/e2e-test/teaspoons_gcp_e2e_cli_test_setup.py
@@ -112,11 +112,11 @@ try:
     logging.info("updating imputation workspace info")
     update_imputation_pipeline_workspace(teaspoons_url, billing_project_name, workspace_name, wdl_method_version, admin_token)
 
-    # query for user quota consumed before running pipeline, expect the default of 0
-    assert 0 == query_for_user_quota_consumed(teaspoons_url, user_token)
+    # query for user quota consumed before running pipeline, expect the default of 2500
+    assert 2500 == query_for_user_quota_consumed(teaspoons_url, user_token)
     
-    # update user quota limit to 2500
-    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 2500)
+    # update user quota limit to 3000
+    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 3000)
     
     logging.info("SETUP COMPLETE")
 

--- a/e2e-test/teaspoons_gcp_e2e_service_test.py
+++ b/e2e-test/teaspoons_gcp_e2e_service_test.py
@@ -118,10 +118,10 @@ try:
     update_imputation_pipeline_workspace(teaspoons_url, billing_project_name, workspace_name, wdl_method_version, admin_token)
 
     # query for user quota consumed before running pipeline, expect the default of 0
-    assert 0 == query_for_user_quota_consumed(teaspoons_url, user_token)
+    assert 2500 == query_for_user_quota_consumed(teaspoons_url, user_token)
 
-    # update user quota limit to 2500
-    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 2500)
+    # update user quota limit to 3000
+    update_quota_limit_for_user(sam_url, teaspoons_url, admin_token, user_email, 3000)
 
     # prepare teaspoons imputation pipeline run
     logging.info("preparing imputation pipeline run")


### PR DESCRIPTION
For public release, we're setting the default quota for array_imputation to 2500 (see [this PR](https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/240)), so we need to update our e2e tests to expect 2500 rather than 0.

Ticket: https://broadworkbench.atlassian.net/browse/TSPS-580